### PR TITLE
Switch old CPP references to CMaize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,10 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" CACHE STRING "" FORCE)
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-        set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE) #For projects including CMakeTest
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE) #For projects including CMakeTest
 endif()
 
-include("${PROJECT_SOURCE_DIR}/cmake/get_cpp.cmake")
+include("${PROJECT_SOURCE_DIR}/cmake/get_cmaize.cmake")
 include(cmake_test/cmake_test)
 
 if("${BUILD_TESTING}")

--- a/cmake/get_cmaize.cmake
+++ b/cmake/get_cmaize.cmake
@@ -7,30 +7,27 @@ include_guard()
 # parent project's configure step (namely we do not want to build CMakePP's
 # unit tests).
 #]]
-function(get_cpp)
-    include(cpp/cpp OPTIONAL RESULT_VARIABLE cpp_found)
-    if(NOT cpp_found)
-
-
-
+function(get_cmaize)
+    include(cmaize/cmaize OPTIONAL RESULT_VARIABLE cmaize_found)
+    if(NOT cmaize_found)
         # Store whether we are building tests or not, then turn off the tests
         set(build_testing_old "${BUILD_TESTING}")
         set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
         # Download CMakePP and bring it into scope
         include(FetchContent)
         FetchContent_Declare(
-             cpp
-             GIT_REPOSITORY https://github.com/CMakePP/CMakePackagingProject
-       )
-       FetchContent_MakeAvailable(cpp)
+            cmaize
+            GIT_REPOSITORY https://github.com/CMakePP/CMaize
+        )
+        FetchContent_MakeAvailable(cmaize)
 
-       # Restore the previous value
-       set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
+        # Restore the previous value
+        set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
     endif()
 endfunction()
 
-# Call the function we just wrote to get CMakePP
-get_cpp()
+# Call the function we just wrote to get CMaize
+get_cmaize()
 
-# Include CMakePP
-include(cpp/cpp)
+# Include CMaize
+include(cmaize/cmaize)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION "${_ct_min_cmake_version}") #Required for FetchContent_MakeAvailable()
 
 include(cmake_test/cmake_test)
-include("${PROJECT_SOURCE_DIR}/cmake/get_cpp.cmake")
+include("${PROJECT_SOURCE_DIR}/cmake/get_cmaize.cmake")
 
 #Sets print length to cached variable. This value is propagated
 #to all tests but can be overriden with subsequent calls or


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Issue #62.

**Description**
Switches CMakeTest to use the new CMaize implementation. This amounts to changing the `get_cpp.cmake` file to `get_cmaize.cmake` and changing all of the references from `cpp` to `cmaize`.

**TODOs**

- [x] Test that CMaize and CMakePPLang tests still work after this change. I am working on this now.
