### PR TITLE
Add tag and release workflow

### DIFF
--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,0 +1,27 @@
+# Copyright 2021 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Tag and Release
+
+on:
+  pull_request:
+    types:
+      - closed # N.B. below we check that it was merged too
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    uses: CMakePP/.github/.github/workflows/tag_and_release_master.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #64.

**Description**
Introduces a workflow to tag merged PRs with versions and create a release for each version. This is pulled verbatim from CMakePPLang.

**TODOs**
- [x] Create the `bump:major`, `bump:minor`, and `bump:patch` labels.
