### PR TITLE
Factor out documentation testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,3 @@ jobs:
         run: |
           cd build
           ../cmake-${cmake_version}-${os}/bin/ctest  -j 2 --output-on-failure
-  docs_test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "docs/"
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -1,0 +1,14 @@
+name: CMakePPLang Documentation Test
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  docs_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Factors out documentation testing into its own workflow file to keep it separate from the unit testing CI. The newly added file was copied from CMakePPLang, although it matched almost exactly the contents of the `doc_tests` job that already existed in `ci.yml`.

**TODOs**

- [ ] Once this is merged, add it as a required test for PRs.
