### PR TITLE
Keep test and CMakeTest debug modes separate for performance improvements

### DIFF
--- a/cmake/cmake_test/add_section.cmake
+++ b/cmake/cmake_test/add_section.cmake
@@ -62,6 +62,13 @@ include_guard()
 #
 #]]
 function(ct_add_section)
+
+    # Set debug mode to what it should be for cmaketest, in case the test changed it
+    set(_as_temp_debug_mode "${CMAKEPP_LANG_DEBUG_MODE}")
+    cpp_get_global(_as_ct_debug_mode "CT_DEBUG_MODE")
+    set(CMAKEPP_LANG_DEBUG_MODE "${_as_ct_debug_mode}")
+    cpp_set_global("CT_CURR_TEST_DEBUG_MODE" "${_as_temp_debug_mode}")
+
     cpp_get_global(_as_curr_instance "CT_CURRENT_EXECUTION_UNIT_INSTANCE")
     CTExecutionUnit(GET "${_as_curr_instance}" _as_parent_print_length print_length)
     CTExecutionUnit(GET "${_as_curr_instance}" _as_parent_print_length_forced print_length_forced)
@@ -93,6 +100,8 @@ function(ct_add_section)
     if(_as_exec_expectfail)
         if("${${CT_ADD_SECTION_NAME}}" STREQUAL "" OR "${${CT_ADD_SECTION_NAME}}" STREQUAL "_")
             set("${CT_ADD_SECTION_NAME}" "_" PARENT_SCOPE)
+            # Reset debug mode in case test changed it
+            set(CMAKEPP_LANG_DEBUG_MODE "${_as_temp_debug_mode}")
             return() #If section is not part of the call tree, immediately return
         endif()
     endif()
@@ -109,7 +118,7 @@ function(ct_add_section)
     if(_as_exec_section) #Time to execute our section
         CTExecutionUnit(GET "${_as_curr_instance}" _as_parent_children children)
         cpp_map(GET "${_as_parent_children}" _as_curr_section_instance "${_as_curr_section_id}")
-
+        # Debug mode reset in execute()
         CTExecutionUnit(execute "${_as_curr_section_instance}")
     else()
         #First time run, construct and configure
@@ -131,6 +140,8 @@ function(ct_add_section)
         CTExecutionUnit(GET "${_as_curr_instance}" _as_siblings section_names_to_ids)
         cpp_map(SET "${_as_siblings}" "${CT_ADD_SECTION_NAME}" "${${CT_ADD_SECTION_NAME}}")
 
+        # Reset debug mode in case test changed it
+        set(CMAKEPP_LANG_DEBUG_MODE "${_as_temp_debug_mode}")
     endif()
 
 endfunction()

--- a/cmake/cmake_test/add_test.cmake
+++ b/cmake/cmake_test/add_test.cmake
@@ -50,6 +50,12 @@ include_guard()
 #
 #]]
 macro(ct_add_test)
+    # Set debug mode to what it should be for cmaketest, in case the test changed it
+    set(_at_temp_debug_mode "${CMAKEPP_LANG_DEBUG_MODE}")
+    cpp_get_global(_at_ct_debug_mode "CT_DEBUG_MODE")
+    set(CMAKEPP_LANG_DEBUG_MODE "${_at_ct_debug_mode}")
+    cpp_set_global("CT_CURR_TEST_DEBUG_MODE" "${_at_temp_debug_mode}")
+
     cpp_get_global(_at_exec_unit_instance "CT_CURRENT_EXECUTION_UNIT_INSTANCE")
     cpp_get_global(_at_exec_expectfail "CT_EXEC_EXPECTFAIL") #Unset in main interpreter, TRUE in subprocess
 
@@ -92,6 +98,9 @@ macro(ct_add_test)
 
         message("Test w/ friendly name \"${CT_ADD_TEST_NAME}\" has ID \"${${CT_ADD_TEST_NAME}}\" and file \"${CMAKE_CURRENT_LIST_FILE}\"")
     endif()
+
+    # Reset debug mode in case test changed it
+    set(CMAKEPP_LANG_DEBUG_MODE "${_at_temp_debug_mode}")
 endmacro()
 
 

--- a/cmake/cmake_test/cmake_test.cmake
+++ b/cmake/cmake_test/cmake_test.cmake
@@ -28,6 +28,9 @@ set(_CT_CMAKE_TEST_ROOT ${CMAKE_CURRENT_LIST_DIR})
 #Capture the templates directory and expose as constant
 set(_CT_TEMPLATES_DIR "${CMAKE_CURRENT_LIST_DIR}/templates")
 
+# Capture whether we want to debug CMakeTest itself
+cpp_set_global("CT_DEBUG_MODE" "${CMAKEPP_LANG_DEBUG_MODE}")
+
 # Despite the way a unit test looks to the user, this is the only module the
 # user needs to load.
 

--- a/cmake/cmake_test/execution_unit.cmake
+++ b/cmake/cmake_test/execution_unit.cmake
@@ -251,9 +251,15 @@ cpp_class(CTExecutionUnit)
 			ct_expectfail_subprocess("${self}")
 
 		else()
-			
 			CTExecutionUnit(GET "${self}" id test_id)
+			# Defer setting the debug mode to as late as possible
+			# Disable in case test does not want debug mode
+			cpp_get_global(ct_debug_mode "CT_DEBUG_MODE")
+			cpp_get_global(test_debug_mode "CT_CURR_TEST_DEBUG_MODE")
+			set(CMAKEPP_LANG_DEBUG_MODE "${test_debug_mode}")
 			cpp_call_fxn("${id}")
+			# Reset the debug mode back to what it should be in case test modified it
+			set(CMAKEPP_LANG_DEBUG_MODE "${ct_debug_mode}")
 		endif()
 		cpp_set_global("CT_CURRENT_EXECUTION_UNIT_INSTANCE" "${old_instance}")
 
@@ -273,22 +279,28 @@ cpp_class(CTExecutionUnit)
 	#
 	#]]
 	cpp_member(exec_sections CTExecutionUnit)
-        function("${exec_sections}" self)
-        	CTExecutionUnit(GET "${self}" _es_expect_fail expect_fail)
-        	cpp_get_global(_es_exec_expectfail "CT_EXEC_EXPECTFAIL")
+    function("${exec_sections}" self)
+        CTExecutionUnit(GET "${self}" _es_expect_fail expect_fail)
+        cpp_get_global(_es_exec_expectfail "CT_EXEC_EXPECTFAIL")
         
-        	# Get whether this section has subsections, only run again if subsections detected
+        # Get whether this section has subsections, only run again if subsections detected
 		CTExecutionUnit(GET "${self}" _es_children_map children)
 		cpp_map(KEYS "${_es_children_map}" _es_has_subsections)
 		
 		#If in main interpreter and not expecting to fail OR in subprocess
 		if((NOT _es_has_subsections STREQUAL "") AND ((NOT _es_expect_fail AND NOT _es_exec_expectfail) OR (_es_exec_expectfail)))		
 			cpp_get_global(old_instance "CT_CURRENT_EXECUTION_UNIT_INSTANCE")
-        	        cpp_set_global("CT_CURRENT_EXECUTION_UNIT_INSTANCE" "${self}")
-        	        CTExecutionUnit(SET "${self}" execute_sections TRUE)
-        	        CTExecutionUnit(GET "${self}" id test_id)
-        	        cpp_call_fxn("${id}")
-	                cpp_set_global("CT_CURRENT_EXECUTION_UNIT_INSTANCE" "${old_instance}")
+        	cpp_set_global("CT_CURRENT_EXECUTION_UNIT_INSTANCE" "${self}")
+        	CTExecutionUnit(SET "${self}" execute_sections TRUE)
+        	CTExecutionUnit(GET "${self}" id test_id)
+        	# Defer setting the debug mode to as late as possible
+        	cpp_get_global(_es_ct_debug_mode "CT_DEBUG_MODE")
+        	cpp_get_global(test_debug_mode "CT_CURR_TEST_DEBUG_MODE")
+			set(CMAKEPP_LANG_DEBUG_MODE "${test_debug_mode}")
+        	cpp_call_fxn("${id}")
+        	# Reset the debug mode back to what it should be in case test modified it
+			set(CMAKEPP_LANG_DEBUG_MODE "${_es_ct_debug_mode}")
+	        cpp_set_global("CT_CURRENT_EXECUTION_UNIT_INSTANCE" "${old_instance}")
 
 		endif()
 

--- a/cmake/cmake_test/expectfail_subprocess.cmake
+++ b/cmake/cmake_test/expectfail_subprocess.cmake
@@ -65,6 +65,8 @@ function(ct_expectfail_subprocess _es_curr_section_instance)
                 #Replace list-delimiters with newlines and parentheses, constructing a function call list
                 string (REGEX REPLACE "(^|[^\\\\]);" "\\1\(\)\n" _es_section_parent_tree "${_es_section_parent_tree}")
 
+                cpp_get_global(ct_debug_mode "CT_DEBUG_MODE")
+
                 #Write subprocess file
                 #Fill in boilerplate, copy to build dir
                 configure_file(

--- a/cmake/cmake_test/overrides.cmake
+++ b/cmake/cmake_test/overrides.cmake
@@ -27,6 +27,10 @@ include_guard()
 # If the first argument is not FATAL_ERROR, this function will behave exactly as the original message().
 #]]
 function(message)
+    # Set debug mode to what it should be for cmaketest, in case the test changed it
+    set(_m_temp_debug_mode "${CMAKEPP_LANG_DEBUG_MODE}")
+    cpp_get_global(_m_ct_debug_mode "CT_DEBUG_MODE")
+    set(CMAKEPP_LANG_DEBUG_MODE "${_m_ct_debug_mode}")
     if(ARGC GREATER 1)
         set(_msg_message_with_level "${ARGV}")
         list(REMOVE_AT _msg_message_with_level 0)
@@ -42,6 +46,7 @@ function(message)
 
             else()
                 cpp_raise(GENERIC_ERROR "${ARGV1}")
+                set(CMAKEPP_LANG_DEBUG_MODE "${_m_temp_debug_mode}")
                 return()
             endif()
         endif()
@@ -55,6 +60,8 @@ function(message)
     else()
         _message(${ARGV})
     endif()
+
+    set(CMAKEPP_LANG_DEBUG_MODE "${_m_temp_debug_mode}")
 endfunction()
 
 

--- a/cmake/cmake_test/register_exception_handler.cmake
+++ b/cmake/cmake_test/register_exception_handler.cmake
@@ -51,7 +51,7 @@ function(ct_register_exception_handler)
 
         cpp_append_global(CMAKETEST_FAILED_TESTS "${_ae_curr_exec_instance}")
 
-	CTExecutionUnit(GET "${_ae_curr_exec_instance}" _ae_section_depth section_depth)
+	    CTExecutionUnit(GET "${_ae_curr_exec_instance}" _ae_section_depth section_depth)
 
         _ct_print_fail("${_ae_friendly_name}" "${_ae_section_depth}" "${_ae_print_length}")
 

--- a/cmake/cmake_test/templates/expectfail.txt
+++ b/cmake/cmake_test/templates/expectfail.txt
@@ -18,6 +18,8 @@ set(CMAKE_MODULE_PATH "@CMAKE_MODULE_PATH@" CACHE STRING "" FORCE)
 
 include("cmake_test/cmake_test")
 
+cpp_set_global("CT_DEBUG_MODE" "@ct_debug_mode@")
+
 cpp_set_global("CT_EXEC_EXPECTFAIL" TRUE)
 
 

--- a/cmake/cmake_test/templates/lists.txt
+++ b/cmake/cmake_test/templates/lists.txt
@@ -11,6 +11,8 @@ project(@_ad_test_file@ LANGUAGES C) #Needed so dummy libraries don't complain a
 #Enable colors in Unix environments, ignored on Windows. Will not work with pipes
 set(CMAKETEST_USE_COLORS "@CMAKETEST_USE_COLORS@")
 
+set(CMAKEPP_LANG_DEBUG_MODE "@CMAKEPP_LANG_DEBUG_MODE@")
+
 #Propagate CT_PRINT_LENGTH if not already set
 if(NOT CT_PRINT_LENGTH GREATER 0)
     set(CT_PRINT_LENGTH "@CT_PRINT_LENGTH@")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,5 +10,7 @@ include("${PROJECT_SOURCE_DIR}/cmake/get_cmaize.cmake")
 set(CT_DEFAULT_PRINT_LENGTH 80 CACHE STRING "The default print length for pass/fail lines. Can be overriden by individual tests.")
 ct_set_print_length("${CT_DEFAULT_PRINT_LENGTH}")
 
+set(CMAKEPP_LANG_DEBUG_MODE ON)
+
 ct_add_dir("./cmake_test")
 ct_add_dir("./test_directory_2")

--- a/tests/cmake_test/debug_mode.cmake
+++ b/tests/cmake_test/debug_mode.cmake
@@ -1,0 +1,21 @@
+
+
+ct_add_test(NAME test_debug_mode)
+function(${test_debug_mode})
+    cpp_get_global(ct_debug_mode "CT_DEBUG_MODE")
+    ct_assert_true(ct_debug_mode)
+    ct_assert_true(CMAKEPP_LANG_DEBUG_MODE)
+endfunction()
+
+ct_add_test(NAME test_debug_mode_set_false)
+function(${test_debug_mode_set_false})
+    set(CMAKEPP_LANG_DEBUG_MODE FALSE)
+
+    ct_add_section(NAME test_cmakepplang_debug_mode)
+    function(${test_cmakepplang_debug_mode})
+
+        cpp_get_global(ct_debug_mode "CT_DEBUG_MODE")
+        ct_assert_true(ct_debug_mode)
+        ct_assert_false(CMAKEPP_LANG_DEBUG_MODE)
+    endfunction()
+endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #82 

**Description**
This PR resets the variable `CMAKEPP_LANG_DEBUG_MODE` when entering CMakeTest code to prevent significant performance degradation for tests setting that variable.

**TODOs**

- [x] Check whether setting debug mode before executing CMakeTest correctly tests the internals, i.e. is debug mode reset to the correct value
- [x] Add tests
- [x] Test with CMakePPLang and CMaize
