### PR TITLE
Fix docs badge on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ CMakeTest
 .. image:: https://github.com/CMakePP/CMakeTest/workflows/CMakeTest%20Unit%20Tests/badge.svg
    :target: https://github.com/CMakePP/CMakeTest/workflows/CMakeTest%20Unit%20Tests/badge.svg
 
-.. image:: https://github.com/CMakePP/CMakeTest/workflows/deploy_docs.yml/badge.svg?branch=master
-   :target: https://github.com/CMakePP/CMakeTest/workflows/deploy_docs.yml/badge.svg?branch=master
+.. image:: https://github.com/CMakePP/CMakeTest/workflows/Build%20and%20Deploy%20Documentation/badge.svg?branch=master
+   :target: https://github.com/CMakePP/CMakeTest/workflows/Build%20and%20Deploy%20Documentation/badge.svg?branch=master
 
 CMake ships with CTest_ which helps integrate your project's tests into your
 project's build system. CTest is a powerful solution for managing your

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ CMakeTest
 .. image:: https://github.com/CMakePP/CMakeTest/workflows/CMakeTest%20Unit%20Tests/badge.svg
    :target: https://github.com/CMakePP/CMakeTest/workflows/CMakeTest%20Unit%20Tests/badge.svg
 
-.. image:: https://github.com/CMakePP/CMakeTest/workflows/Build%20and%20Deploy%20Documentation/badge.svg?branch=master
-   :target: https://github.com/CMakePP/CMakeTest/workflows/Build%20and%20Deploy%20Documentation/badge.svg?branch=master
+.. image:: https://github.com/CMakePP/CMakeTest/workflows/Build%20and%20Deploy%20Documentation/badge.svg
+   :target: https://github.com/CMakePP/CMakeTest/workflows/Build%20and%20Deploy%20Documentation/badge.svg
 
 CMake ships with CTest_ which helps integrate your project's tests into your
 project's build system. CTest is a powerful solution for managing your


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #84 

**Description**
This just changes the badge URL in the README.rst to the correct one for the docs action.

**Note**
Apparently, those URLs are based on the name of the workflow, so if we change the name we'd need to change these URLs again, even if the workflow filename remains the same
