### PR TITLE
Allow types as test section names

### DIFF
--- a/cmake/cmake_test/add_section.cmake
+++ b/cmake/cmake_test/add_section.cmake
@@ -83,7 +83,16 @@ function(ct_add_section)
     cmake_parse_arguments(CT_ADD_SECTION "${_as_options}" "${_as_one_value_args}"
                           "${_as_multi_value_args}" ${ARGN} )
 
+    # This is to set a default value for the print length
+    # argument to prevent any weird empty strings from getting through
+    if(NOT DEFINED CT_ADD_SECTION_PRINT_LENGTH)
+        set(CT_ADD_SECTION_PRINT_LENGTH 0)
+    endif()
 
+    # Assert sig doesn't work too well with the position agnostic kwargs,
+    # so first we parse the arguments and then we check their types.
+    # Right now, allow any type for the name
+    cpp_assert_signature("${CT_ADD_SECTION_NAME};${CT_ADD_SECTION_PRINT_LENGTH}" str int)
 
     set(_as_print_length_forced "NO")
 

--- a/cmake/cmake_test/add_test.cmake
+++ b/cmake/cmake_test/add_test.cmake
@@ -53,6 +53,11 @@ include_guard()
 #
 #]]
 macro(ct_add_test)
+
+    #####################################
+    #   Context switch and arg parsing  #
+    #####################################
+
     # Set debug mode to what it should be for cmaketest, in case the test changed it
     set(_at_temp_debug_mode "${CMAKEPP_LANG_DEBUG_MODE}")
     cpp_get_global(_at_ct_debug_mode "CT_DEBUG_MODE")
@@ -79,6 +84,7 @@ macro(ct_add_test)
 
     if(_at_exec_expectfail AND ("${${CT_ADD_TEST_NAME}}" STREQUAL "" OR "${${CT_ADD_TEST_NAME}}" STREQUAL "_"))
             set("${CT_ADD_TEST_NAME}" "_")
+            set(CMAKETEST_TEST "_" PARENT_SCOPE)
             # Reset debug mode in case test changed it
             set(CMAKEPP_LANG_DEBUG_MODE "${_at_temp_debug_mode}")
     else()
@@ -96,6 +102,7 @@ macro(ct_add_test)
 
         if(_at_old_id STREQUAL "")
             cpp_unique_id("${CT_ADD_TEST_NAME}")
+            set(CMAKETEST_TEST "${${CT_ADD_TEST_NAME}}")
         endif()
 
         if(_at_exec_expectfail OR ("${_at_old_id}" STREQUAL ""))

--- a/cmake/cmake_test/add_test.cmake
+++ b/cmake/cmake_test/add_test.cmake
@@ -18,17 +18,33 @@ include_guard()
 #
 # Unit testing in CMakeTest works by `include()`ing each unit test, determining which ones
 # need to be ran, and then executing them sequentially in-process. This macro defines which functions
-# are to be interpretted as actual unit tests. It does so by setting a variable in the calling scope
-# that is to be used as the function identifier. For example:
+# are to be interpretted as actual unit tests.
+#
+# A variable named :code:`CMAKETEST_TEST` will be set in the
+# calling scope that holds the test function ID. Use this variable
+# to define the CMake function holding the section code. Ex:
+#
+# .. code-block:: cmake
+#
+#    ct_add_test(NAME [=[Any test name here]=])
+#    function(${CMAKETEST_TEST})
+#        message(STATUS "This code will run in a test")
+#    endfunction()
+#
+#
+# Additionally, the NAME parameter will be populated as by set() with the
+# generated section function name. This is for backwards-compatibility
+# purposes. Ex:
 #
 # .. code-block:: cmake
 #
 #    ct_add_test(NAME this_test)
 #    function(${this_test})
-#        message(STATUS "This code will run in a unit test")
+#        message(STATUS "This code will run in a test")
 #    endfunction()
 #
-# This helps tests avoid name collisions and also allows the testing framework to keep track of them.
+# This behavior is considered deprecated, use the first form
+# for new tests.
 #
 # Print length of pass/fail lines can be adjusted with the `PRINT_LENGTH` option.
 #

--- a/cmake/cmake_test/detail_/utilities/print_result.cmake
+++ b/cmake/cmake_test/detail_/utilities/print_result.cmake
@@ -103,7 +103,7 @@ endfunction()
 # :type print_length: int
 #]]
 function(_ct_print_pass _pp_name _pp_depth _pp_print_length)
-    cpp_assert_signature("${ARGV}" desc int int)
+    cpp_assert_signature("${ARGV}" str int int)
     _ct_print_result("${_pp_name}" "${CT_BoldGreen}PASSED${CT_ColorReset}" "${_pp_depth}" "${_pp_print_length}")
 endfunction()
 
@@ -124,6 +124,6 @@ endfunction()
 # :type print_length: int
 #]]
 function(_ct_print_fail _pf_name _pf_depth _pf_print_length)
-    cpp_assert_signature("${ARGV}" desc int int)
+    cpp_assert_signature("${ARGV}" str int int)
     _ct_print_result("${_pf_name}" "${CT_BoldRed}FAILED${CT_ColorReset}" "${_pf_depth}" "${_pf_print_length}")
 endfunction()

--- a/cmake/cmake_test/execution_unit.cmake
+++ b/cmake/cmake_test/execution_unit.cmake
@@ -177,9 +177,9 @@ cpp_class(CTExecutionUnit)
     # :param expect_fail: Whether this unit is expected to fail.
     #
     #]]
-    cpp_constructor(CTOR CTExecutionUnit str desc* bool)
+    cpp_constructor(CTOR CTExecutionUnit str str bool)
     function("${CTOR}" self test_id friendly_name expect_fail)
-        # Name could be a description or a function because it
+        # Name could be a description, a type, or a function because it
         # isn't considered invalid to do so, such as using
         # a test name of "set"
         #

--- a/docs/source/writing_tests/basic_test.rst
+++ b/docs/source/writing_tests/basic_test.rst
@@ -31,6 +31,17 @@ This is required to link the function definition with the test. The
 value of the implicitly set :code:`CMAKETEST_TEST` variable is a unique
 identifier for the test, it's only used internally.
 
+The name of the test may be any string and can include special characters.
+If the name has such special characters, pass it as a bracket argument
+instead of as a quoted argument.
+
+.. note::
+   There is a secondary, deprecated form of naming tests and sections.
+   This secondary form has restrictions on the name given such that it
+   is a valid CMake variable identifier. New tests and sections should
+   use the above form instead. See :obj:`~cmake_test/add_test.ct_add_test`
+   for information on the deprecated form.
+
 Inside the function one will notice a call to
 :obj:`~cmake_test/asserts/prints.ct_assert_prints`.
 This is one of the included assertion functions. If an assertion fails,

--- a/docs/source/writing_tests/basic_test.rst
+++ b/docs/source/writing_tests/basic_test.rst
@@ -26,12 +26,10 @@ a particular string is printed.
 
 The :obj:`~cmake_test/add_test.ct_add_test` call tells CMakeTest that there is a test
 with the name :code:`hello_world`. The function definition below it
-defines the test. Note the odd :code:`${hello_world}` used as the
-function name. This is required to link the function definition with
-the :code:`ct_add_test()` call. :code:`ct_add_test()` takes the test name
-and assigns a unique identifier to it to keep track of the accompanying
-definition. Thus, if you use the same name for multiple tests in the same
-scope they will conflict.
+defines the test. Note the odd :code:`${CMAKETEST_TEST}` as the function name.
+This is required to link the function definition with the test. The
+value of the implicitly set :code:`CMAKETEST_TEST` variable is a unique
+identifier for the test, it's only used internally.
 
 Inside the function one will notice a call to
 :obj:`~cmake_test/asserts/prints.ct_assert_prints`.

--- a/tests/cmake_test/add_section.cmake
+++ b/tests/cmake_test/add_section.cmake
@@ -35,15 +35,20 @@ function(${test_add_section_top_level})
 
     ct_add_section(NAME invalid_name EXPECTFAIL)
     function("${invalid_name}")
-        # CMake won't allow a variable name with spaces, so making a test
-        # with such a name is impossible with the current implementation.
-        # Well, technically not impossible, if you set a different
-        # variable to the text "incomprehensible with spaces"
-        # you can then double deference it to get the function identifier out.
-        # We probably don't want to deal with that though
+        # CMake won't allow a variable dereference with spaces,
+        # so the old way of naming sections should fail
         ct_add_section(NAME "incomprehensible with spaces")
         function("${incomprehensible with spaces}")
            message("This cannot be")
+        endfunction()
+    endfunction()
+
+    ct_add_section(NAME arbitrary_name)
+    function("${arbitrary_name}")
+        # CMakeTest should now support arbitrary section names
+        ct_add_section(NAME "Whatever we want to call it, with $pecial ch&rs")
+        function("${CMAKETEST_SECTION}")
+           cpp_set_global(TEST_ADD_SECTION_S4 TRUE)
         endfunction()
     endfunction()
 
@@ -53,12 +58,14 @@ ct_add_test(NAME test_sections_were_run)
 function(${test_sections_were_run})
    cpp_get_global(s0 TEST_ADD_SECTION_S0)
    cpp_get_global(s1 TEST_ADD_SECTION_S1)
+   cpp_get_global(s4 TEST_ADD_SECTION_S4)
    cpp_get_global(s_s0 TEST_ADD_SECTION_S_S0)
    cpp_get_global(s_s1 TEST_ADD_SECTION_S_S1)
 
 
    ct_assert_true(s0)
    ct_assert_true(s1)
+   ct_assert_true(s4)
    ct_assert_true(s_s0)
    ct_assert_true(s_s1)
 endfunction()

--- a/tests/cmake_test/add_section.cmake
+++ b/tests/cmake_test/add_section.cmake
@@ -18,6 +18,33 @@ function(${test_add_section_top_level})
        function(${subsection_0})
            cpp_set_global(TEST_ADD_SECTION_S_S0 TRUE)
        endfunction()
+
+       ct_add_section(NAME bool)
+       function(${bool})
+           cpp_set_global(TEST_ADD_SECTION_S_S1 TRUE)
+       endfunction()
+    endfunction()
+
+    ct_add_section(NAME wrong_sig EXPECTFAIL)
+    function("${wrong_sig}")
+        ct_add_section(NAME "invalid_print_length" PRINT_LENGTH FALSE)
+        function("${invalid_print_length}")
+           message("This cannot be")
+        endfunction()
+    endfunction()
+
+    ct_add_section(NAME invalid_name EXPECTFAIL)
+    function("${invalid_name}")
+        # CMake won't allow a variable name with spaces, so making a test
+        # with such a name is impossible with the current implementation.
+        # Well, technically not impossible, if you set a different
+        # variable to the text "incomprehensible with spaces"
+        # you can then double deference it to get the function identifier out.
+        # We probably don't want to deal with that though
+        ct_add_section(NAME "incomprehensible with spaces")
+        function("${incomprehensible with spaces}")
+           message("This cannot be")
+        endfunction()
     endfunction()
 
 endfunction()
@@ -27,9 +54,11 @@ function(${test_sections_were_run})
    cpp_get_global(s0 TEST_ADD_SECTION_S0)
    cpp_get_global(s1 TEST_ADD_SECTION_S1)
    cpp_get_global(s_s0 TEST_ADD_SECTION_S_S0)
+   cpp_get_global(s_s1 TEST_ADD_SECTION_S_S1)
 
 
    ct_assert_true(s0)
    ct_assert_true(s1)
    ct_assert_true(s_s0)
+   ct_assert_true(s_s1)
 endfunction()

--- a/tests/cmake_test/add_test.cmake
+++ b/tests/cmake_test/add_test.cmake
@@ -16,3 +16,17 @@ function(${test_test_was_run_once})
     cpp_get_global(counter "TEST_ADD_TEST_COUNTER")
     ct_assert_equal(counter 1)
 endfunction()
+
+
+ct_add_test(NAME [[arbitrary test name with $pecial ch&rs]])
+function(${CMAKETEST_TEST})
+    cpp_get_global(counter "TEST_ADD_TEST_2_COUNTER")
+    math(EXPR counter ${counter}+1)
+    cpp_set_global("TEST_ADD_TEST_2_COUNTER" ${counter})
+endfunction()
+
+ct_add_test(NAME test_test_2_was_run_once)
+function(${test_test_2_was_run_once})
+    cpp_get_global(counter "TEST_ADD_TEST_2_COUNTER")
+    ct_assert_equal(counter 1)
+endfunction()

--- a/tests/cmake_test/basic_section.cmake
+++ b/tests/cmake_test/basic_section.cmake
@@ -2,10 +2,10 @@
 # This file just shows how to write a basic test section.
 #]]
 ct_add_test(NAME basic_test)
-function(${basic_test})
+function(${CMAKETEST_TEST})
 
     ct_add_section(NAME basic_section)
-    function(${basic_section})
+    function(${CMAKETEST_SECTION})
 
         message("Basic Section")
         ct_assert_prints("Basic Section")

--- a/tests/cmake_test/expectfail.cmake
+++ b/tests/cmake_test/expectfail.cmake
@@ -5,7 +5,7 @@ include(cmake_test/cmake_test)
 # in an EXPECTFAIL test will allow the test to succeed.
 #]]
 ct_add_test(NAME "make_sure_function_fails" EXPECTFAIL)
-function("${make_sure_function_fails}")
+function("${CMAKETEST_TEST}")
 
     function(failing_fxn)
         message(FATAL_ERROR "I have erred.")

--- a/tests/cmake_test/tutorials/1_hello_world.cmake
+++ b/tests/cmake_test/tutorials/1_hello_world.cmake
@@ -27,7 +27,7 @@ include(cmake_test/cmake_test)
 #As an introductory example we write a simple unit test that prints
 #"Hello World" and asserts that "Hello World" was indeed printed.
 ct_add_test(NAME hello_world)
-function(${hello_world})
+function(${CMAKETEST_TEST})
     message("Hello World")
     ct_assert_prints("Hello World")
 endfunction()

--- a/tests/cmake_test/tutorials/2_sections.cmake
+++ b/tests/cmake_test/tutorials/2_sections.cmake
@@ -20,7 +20,7 @@
 #think it does.
 include(cmake_test/cmake_test)
 ct_add_test(NAME "_test_sections")
-function(${_test_sections})
+function(${CMAKETEST_TEST})
     set(common "This variable is available to all tests")
     ct_assert_equal(common "This variable is available to all tests")
 
@@ -51,7 +51,7 @@ function(${_test_sections})
     #``ct_end_test``, whereas all inner scopes (even scopes within sections) are
     #started with ``ct_add_section`` and ended with ``endfunction``.
     ct_add_section(NAME "_scoped_variable")
-    function(${_scoped_variable})
+    function(${CMAKETEST_SECTION})
 
         #TUTORIAL
         #
@@ -78,7 +78,7 @@ function(${_test_sections})
         # 3. Length set by ct_set_print_length()
         # 4. Built-in default of 80.
         ct_add_section(NAME "_nested_section" PRINT_LENGTH 180)
-        function(${_nested_section})
+        function(${CMAKETEST_SECTION})
             set(not_common "This change only matters here")
             ct_assert_equal(common "This variable is available to all tests")
             ct_assert_equal(not_common "This change only matters here")
@@ -93,7 +93,7 @@ function(${_test_sections})
         set(not_common "Only visible from here forward")
 
         ct_add_section(NAME "_another_nested_section")
-        function(${_another_nested_section})
+        function(${CMAKETEST_SECTION})
             ct_assert_equal(not_common "Only visible from here forward")
         endfunction()
     endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #90 

**Description**
This PR allows CMakePP types to be used as test section names, like `bool`.
Unfortunately, it does not appear possible to blanket allow all test names, since the
name is to also pass a function identifier back. A solution to this would be to add another
parameter to `ct_add_section()` to define the name of the return variable that is then set to the function ID.
Pros would be any name would be valid for a test section, but cons would be two different ways to create a test.

If we wanted to add the new parameter, it would be best to do it as soon as possible, before the 1.0 release. It could be considered that we should remove the old way of implicitly passing the id in the name, but that would require a much larger refactor across all current projects using CMakeTest.

**TODOs**

- [x] Add support for the same in top-level tests
- [x] Add documentation specifying in the user manual what names are and are not allowed
