### PR TITLE
Make include_guard in overrides global

### DIFF
--- a/cmake/cmake_test/overrides.cmake
+++ b/cmake/cmake_test/overrides.cmake
@@ -21,7 +21,7 @@
 #    This module is intended for internal use only
 #]]
 
-include_guard()
+include_guard(GLOBAL)
 
 
 #[[[


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes a very strange bug discovered in https://github.com/CMakePP/CMaize/pull/132 where calling `message()` would result in infinite recursion.

**Description**
Turns out `include_guard()` only works for the current scope by default, so we needed to add an argument to make it a global guard.

**TODOs**
- Probably should investigate usages of `include_guard()` elsewhere as well
