### PR TITLE
Pin sphinx at version less than 7.2.0 to support python 3.8

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+sphinx<7.2.0
 sphinx_rtd_theme
 cminx>=1.1.7


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #95 

**Description**
Simply pins the version of sphinx at less than 7.2.0. However, we should probably check why the actions are failing since the workflow should be using python 3.10 instead
