### PR TITLE
Add error message when forgetting a name and fix bug with expectfail not working with unit names with special characters

### DIFF
--- a/cmake/cmake_test/add_section.cmake
+++ b/cmake/cmake_test/add_section.cmake
@@ -119,8 +119,14 @@ function(ct_add_section)
     set(_as_options EXPECTFAIL)
     set(_as_one_value_args NAME PRINT_LENGTH)
     set(_as_multi_value_args "")
+    unset(CT_ADD_SECTION_NAME)
     cmake_parse_arguments(CT_ADD_SECTION "${_as_options}" "${_as_one_value_args}"
                           "${_as_multi_value_args}" ${ARGN} )
+
+
+    if(NOT DEFINED CT_ADD_SECTION_NAME OR CT_ADD_SECTION_NAME STREQUAL "")
+        cpp_raise(CT_INVALID_NAME_ERROR "A section was not given a name. Use the NAME keyword argument to provide a non-empty string name.")
+    endif()
 
     # This is to set a default value for the print length
     # argument to prevent any weird empty strings from getting through

--- a/cmake/cmake_test/add_test.cmake
+++ b/cmake/cmake_test/add_test.cmake
@@ -98,6 +98,10 @@ macro(ct_add_test)
     cmake_parse_arguments(CT_ADD_TEST "${_at_options}" "${_at_one_value_args}"
                           "${_at_multi_value_args}" ${ARGN} )
 
+    if(NOT DEFINED CT_ADD_TEST_NAME OR CT_ADD_TEST_NAME STREQUAL "")
+        cpp_raise(CT_INVALID_NAME_ERROR "A test was not given a name. Use the NAME keyword argument to provide a non-empty string name.")
+    endif()
+
     if(_at_exec_expectfail AND ("${${CT_ADD_TEST_NAME}}" STREQUAL "" OR "${${CT_ADD_TEST_NAME}}" STREQUAL "_"))
             set("${CT_ADD_TEST_NAME}" "_")
             set(CMAKETEST_TEST "_")

--- a/cmake/cmake_test/expectfail_subprocess.cmake
+++ b/cmake/cmake_test/expectfail_subprocess.cmake
@@ -69,7 +69,7 @@ function(ct_expectfail_subprocess _es_curr_section_instance)
     endforeach()
 
     # Append this section's ID definition so it is executed
-    list(APPEND _es_section_id_defines "set(${_es_section_friendly_name} \"${_es_section_id}\")")
+    list(APPEND _es_section_id_defines "set([[${_es_section_friendly_name}]] \"${_es_section_id}\")")
 
     # Replace list delimiters with newlines for full call list
     string (REGEX REPLACE "(^|[^\\\\]);" "\\1\n" _es_section_id_defines "${_es_section_id_defines}")

--- a/cmake/cmake_test/templates/expectfail.txt
+++ b/cmake/cmake_test/templates/expectfail.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION @_ct_min_cmake_version@) #Required for FetchContent_MakeAvailable()
 
-project(@_es_section_file@ LANGUAGES C) #Needed so dummy libraries don't complain about not having a linkage language
+project([[@_es_section_file@]] LANGUAGES C) #Needed so dummy libraries don't complain about not having a linkage language
 
 
 #Enable colors in Unix environments, ignored on Windows. Will not work with pipes
@@ -30,12 +30,12 @@ ct_register_exception_handler()
 @_es_section_id_defines@
 
 # Set the expect fail target unit so all children can be correctly executed
-cpp_set_global("CT_EXPECTFAIL_TGT" "@_es_section_id@")
+cpp_set_global("CT_EXPECTFAIL_TGT" [[@_es_section_id@]])
 
 set(CMAKEPP_LANG_DEBUG_MODE "@CMAKEPP_LANG_DEBUG_MODE@")
 
 #Include root file
-include("@_es_section_file@")
+include([[@_es_section_file@]])
 
 #Execute the only test there is, ignoring subsections that do not comprise the call tree
 ct_exec_tests()

--- a/cmake/cmake_test/templates/lists.txt
+++ b/cmake/cmake_test/templates/lists.txt
@@ -30,5 +30,5 @@ cpp_set_global("CT_DEBUG_MODE" "@ct_debug_mode@")
 include("cmake_test/cmake_test")
 set(CMAKEPP_LANG_DEBUG_MODE "@CMAKEPP_LANG_DEBUG_MODE@")
 
-include("@_ad_test_file@")
+include([[@_ad_test_file@]])
 ct_exec_tests()

--- a/tests/cmake_test/add_section.cmake
+++ b/tests/cmake_test/add_section.cmake
@@ -5,6 +5,26 @@
 ct_add_test(NAME test_add_section_top_level)
 function(${test_add_section_top_level})
 
+
+    ct_add_section(NAME signature)
+    function(${CMAKETEST_SECTION})
+        ct_add_section(NAME [[No name keyword]] EXPECTFAIL)
+        function(${CMAKETEST_SECTION})
+            ct_add_section([[Ignored the NAME keyword]])
+            function(${CMAKETEST_SECTION})
+
+            endfunction()
+        endfunction()
+
+        ct_add_section(NAME [[No name value]] EXPECTFAIL)
+        function(${CMAKETEST_SECTION})
+            ct_add_section(NAME)
+            function(${CMAKETEST_SECTION})
+
+            endfunction()
+        endfunction()
+    endfunction()
+
     ct_add_section(NAME section_0)
     function(${section_0})
         cpp_set_global(TEST_ADD_SECTION_S0 TRUE)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fix #99 

**Description**
This PR is pretty simple in that it adds a helpful error message to inform users when they forget to use the `NAME` keyword or provide a value for it. It also raises a CPP exception when encountering to prevent anything weird from happening later and to give the user a proper stacktrace. Tests for this were also added.

In the process of fixing this issue I discovered that the `expectfail` template did not work when the section name had spaces, because it was being inserted verbatim into a `set()` command without quotes. This was also fixed by adding bracket quotes around important substitutions, in both templates and in the `expectfail_subprocess` module.

