### PR TITLE
Fix appending of mangled Windows paths

### DIFF
--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -48,6 +48,7 @@ function(ct_add_dir _ad_dir)
         file(RELATIVE_PATH _ad_rel_path "${_ad_abs_test_dir}" "${_ad_test_file}")
         file(TO_CMAKE_PATH "${_ad_abs_test_dir}" _ad_normalized_dir)
         string(REPLACE "/" "_" _ad_dir_prefix "${_ad_normalized_dir}")
+        string(REPLACE ":" "_" _ad_dir_prefix "${_ad_dir_prefix}")
 
         #Fill in boilerplate, copy to build dir
         configure_file(


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #101.

**Description**
CMakeTest adds tests in the build directory under their own directories, distinguishing the directories by using the full path to each test file as the directory name. Currently, this works by replacing `/`, an invalid file name character, with `_` and appears to be sufficient for Linux (and likely macOS). However, Windows absolute paths use `\` as their path separator and have a drive letter at the beginning, separated from the rest of the path with a colon character (for example, `C:\Users\myuser\Documents\file.txt`). CMake can normalize the path separator from `\` to `/`, and this is already being done, but the colon drive letter separator is not being handled. This PR adds handling for the colon character by replacing it with an underscore as well.

**TODOs**
- [x] Are there any other special characters we should worry about? I can't think of any. There are forbidden characters for file names, but since the files have to already exist, other invalid characters should have already been filtered out.
