### PR TITLE
Fix CMakePPLang include in get_cmakepp_lang function

### DIFF
--- a/cmake/get_cmakepp_lang.cmake
+++ b/cmake/get_cmakepp_lang.cmake
@@ -37,7 +37,7 @@ function(get_cmakepp_lang)
         # Store whether we are building tests or not, then turn off the tests
         set(build_testing_old "${BUILD_TESTING}")
         set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
-        # Download CMakePP and bring it into scope
+        # Download CMakePPLang and bring it into scope
         include(FetchContent)
         FetchContent_Declare(
             cmakepp_lang
@@ -57,5 +57,8 @@ function(get_cmakepp_lang)
     endif()
 endfunction()
 
-# Call the function we just wrote to get CMaize
+# Call the function we just wrote to get CMakePPLang
 get_cmakepp_lang()
+
+# Include CMakePPLang
+include(cmakepp_lang/cmakepp_lang)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No, I just noticed this problem while I was fixing another problem.

**Description**
In the `get_cmakepp_lang()` function, if it should mirror the `get_cmaize()` function, it should include CMakePPLang at the end of the file. It currently does not. This PR adds that in and fixes a few minor mistakes in the comments.
