### PR TITLE
Fix CMakePPLang Inclusion Error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-#3.19 needed because of CMaize
+# 3.19 needed because of CMaize
 set(_ct_min_cmake_version "3.19" CACHE INTERNAL "")
 cmake_minimum_required(VERSION "${_ct_min_cmake_version}")
 project(CMakeTest VERSION 1.0.0 LANGUAGES NONE)
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    #Make sure projects using CMakeTest have this variable
+    # Make sure projects using CMakeTest have this variable
     set(_ct_min_cmake_version "${_ct_min_cmake_version}" PARENT_SCOPE)
 endif()
 
@@ -16,14 +16,15 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" CACHE STRING "" FORCE)
 
+# Fetch dependencies
+include(get_cmakepp_lang)
+include(get_cmaize)
+
 # Make sure projects including CMakeTest can find it too
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
 endif()
 
-
-include(get_cmakepp_lang)
-include(get_cmaize)
 include(cmake_test/cmake_test)
 
 if("${BUILD_TESTING}")
@@ -31,5 +32,4 @@ if("${BUILD_TESTING}")
 
     include(CTest)
     add_subdirectory("tests/")
-
 endif()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #105.

**Description**
The correct `CMAKE_MODULE_PATH` including dependencies was not being forwarded from CMakeTest to projects including it through FetchContent. This was because the lines that would set the `CMAKE_MODULE_PATH` to `PARENT_SCOPE` were run *before* CMakePPLang and CMaize were included in the project. This PR moves the code block setting `CMAKE_MODULE_PATH` to the parent scope to after the dependencies have been included.

**TODOs**
- [x] Test on the example project on Linux.
- [x] Test on the example project on Windows.
