### PR TITLE
Update basic_test.rst

### DIFF
--- a/docs/source/writing_tests/basic_test.rst
+++ b/docs/source/writing_tests/basic_test.rst
@@ -21,7 +21,7 @@ a particular string is printed.
 
 .. literalinclude:: ../../../tests/cmake_test/tutorials/1_hello_world.cmake
    :language: cmake
-   :lines: 24-28
+   :lines: 29-33
 
 
 The :obj:`~cmake_test/add_test.ct_add_test` call tells CMakeTest that there is a test


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The code snippet on the documentation website for writing a basic unit test ([here](https://cmakepp.github.io/CMakeTest/writing_tests/basic_test.html)) is not the test definition code that it should be. Instead, it is a snippet of part of the comment above it ([L24-L28](https://github.com/CMakePP/CMakeTest/blob/master/tests/cmake_test/tutorials/1_hello_world.cmake#L24-L28)). This PR updates the literalinclude to be the correct lines in the file ([L29-L33](https://github.com/CMakePP/CMakeTest/blob/master/tests/cmake_test/tutorials/1_hello_world.cmake#L29-L33)).

Currently, it displays:
```
#so the name of the function is the value of the variable
#(``function(${some_test_name})``).
#
#As an introductory example we write a simple unit test that prints
#"Hello World" and asserts that "Hello World" was indeed printed.
```
but should display:
```
ct_add_test(NAME hello_world)
function(${CMAKETEST_TEST})
    message("Hello World")
    ct_assert_prints("Hello World")
endfunction()
```
