### PR TITLE
Fix Windows Path Mangling

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -25,6 +25,6 @@ header:
     - tests/
     - LICENSE
     - requirements.txt
-    - *.txt.in
+    - "*.txt.in"
 
   comment: never

--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -25,5 +25,6 @@ header:
     - tests/
     - LICENSE
     - requirements.txt
+    - *.txt.in
 
   comment: never

--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -25,6 +25,6 @@ header:
     - tests/
     - LICENSE
     - requirements.txt
-    - "*.txt.in"
+    - "**/**.txt.in"
 
   comment: never

--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -105,13 +105,13 @@ function(ct_add_dir _ad_test_dir)
         )
 
         add_test(
-        NAME
-            "${_ad_test_dest_prefix}_${_ad_test_proj_dir}"
-        COMMAND
-            "${CMAKE_COMMAND}"
-               -S "${_ad_test_dest_full_path}/src"
-               -B "${_ad_test_dest_full_path}"
-               ${ADD_DIR_CMAKE_OPTIONS}
+            NAME
+                "${_ad_test_dest_prefix}_${_ad_test_proj_dir}"
+            COMMAND
+                "${CMAKE_COMMAND}"
+                -S "${_ad_test_dest_full_path}/src"
+                -B "${_ad_test_dest_full_path}"
+                ${ADD_DIR_CMAKE_OPTIONS}
         )
     endforeach()
 endfunction()

--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -126,7 +126,7 @@ function(ct_add_dir _ad_test_dir)
 
         # The test name is long right now, but it would likely be much more
         # complicated to make it shorter while still unique and readable
-        set(_ad_test_name "${_CT_CMAKELISTS_TEMPLATE_PROJECT_NAME}")
+        set(_ad_test_name "${_ad_test_file}")
         add_test(
             NAME
                 "${_ad_test_name}"

--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -63,6 +63,13 @@ function(ct_add_dir _ad_test_dir)
     # These directories are created from the mangled path to the source test
     # file in the project to help ensure that each path is unique
     foreach(_ad_test_file ${_ad_test_files})
+        # Set the test file path for configuring the test mini-project
+        set(_CT_LISTS_TEMPLATE_TEST_FILE "${_ad_test_file}")
+
+        # Sanitize the full path to the test file to get the mini-project name
+        # for configuring the test mini-project
+        cpp_sanitize_string(_CT_LISTS_TEMPLATE_PROJECT_NAME "${_ad_test_file}")
+
         # Normalize the absolute path to the project test directory, used in
         # the build directory as a prefixing subdirectory to hold all of the
         # test mini-projects from this test directory
@@ -78,28 +85,25 @@ function(ct_add_dir _ad_test_dir)
             "${_ad_test_file}"
         )
 
-        # string(REPLACE "/" "_" _ad_dir_prefix "${_ad_normalized_dir}")
-        # string(REPLACE ":" "_" _ad_dir_prefix "${_ad_dir_prefix}")
-
         # Mangle all of the directory names derived from paths, since path
         # strings commonly have characters that are illegal in file names
-        # mangle_path(_ad_dir_prefix_mangled "${_ad_normalized_abs_test_dir}")
-        # mangle_path(_ad_rel_path_mangled "${_ad_test_file_rel_path}")
         cpp_sanitize_string(_ad_test_dest_prefix
             "${_ad_normalized_abs_test_dir}"
         )
         cpp_sanitize_string(_ad_test_proj_dir "${_ad_test_file_rel_path}")
 
+        # Create the test destination path in the build directory
         set(_ad_test_dest_full_path
             "${CMAKE_CURRENT_BINARY_DIR}/tests/${_ad_test_dest_prefix}/${_ad_test_proj_dir}"
         )
 
-        # Fill in boilerplate, copy to build dir
+        # Configure the test mini-project in the build directory
         configure_file(
-            "${_CT_TEMPLATES_DIR}/lists.txt"
+            "${_CT_TEMPLATES_DIR}/test_project_CMakeLists.txt.in"
             "${_ad_test_dest_full_path}/src/CMakeLists.txt"
             @ONLY
         )
+
         add_test(
         NAME
             "${_ad_test_dest_prefix}_${_ad_test_proj_dir}"

--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -32,6 +32,10 @@ include(cmakepp_lang/cmakepp_lang)
 #
 # :keyword CT_DEBUG_MODE_ON: Enables debug mode when the tests are run.
 # :type CT_DEBUG_MODE_ON: bool
+# :keyword USE_REL_PATH_NAMES: Enables using shorter, relative paths for
+#                              test names, but increases the chance of name
+#                              collisions.
+# :type USE_REL_PATH_NAMES: bool
 # :keyword CMAKE_OPTIONS: List of additional CMake options to be
 #                         passed to all test invocations. Options
 #                         should follow the syntax:
@@ -44,7 +48,7 @@ function(ct_add_dir _ad_test_dir)
     #       debug mode for the test projects (see the use of 'ct_debug_mode'
     #       in cmake/cmake_test/templates/test_project_CMakeLists.txt.in).
     #       I propose renaming it to something like "ENABLE_DEBUG_MODE_IN_TESTS".
-    set(_ad_options CT_DEBUG_MODE_ON)
+    set(_ad_options CT_DEBUG_MODE_ON USE_REL_PATH_NAMES)
     cmake_parse_arguments(PARSE_ARGV 1 ADD_DIR "${_ad_options}" "" "${_ad_multi_value_args}")
 
     # This variable will be picked up by the template
@@ -124,9 +128,37 @@ function(ct_add_dir _ad_test_dir)
             @ONLY
         )
 
-        # The test name is long right now, but it would likely be much more
-        # complicated to make it shorter while still unique and readable
-        set(_ad_test_name "${_ad_test_file}")
+        if (ADD_DIR_USE_REL_PATH_NAMES)
+            # Option 1 - shortest but highest collision likelyhood
+            # Prepend the test name to the relative path to test file from the
+            # given test directory
+
+            # set(_ad_test_name "${}/${_ad_test_file_rel_path}")
+
+
+            # Option 2 - longest but least collision likelyhood
+            # Get the path from the root of the project, with the project name
+            # prepended
+
+            # Generate relative path from project root for the test name
+            # file(RELATIVE_PATH
+            #     _ad_test_file_rel_path_from_proj_root
+            #     "${PROJECT_SOURCE_DIR}"
+            #     "${_ad_test_file}"
+            # )
+            # # Prepend the project name to the relative path
+            # set(_ad_test_name "${PROJECT_NAME}/${_ad_test_file_rel_path_from_proj_root}")
+
+
+            # Option 3 - in-between length and collision likelyhood
+            # Prepend the project name and given test directory name to the
+            # test file relative path
+            
+            get_filename_component(_ad_test_dir_name "${_ad_test_dir}" NAME)
+            set(_ad_test_name "${PROJECT_NAME}::${_ad_test_dir_name}/${_ad_test_file_rel_path}")
+        else()
+            set(_ad_test_name "${_ad_test_file}")
+        endif()
         add_test(
             NAME
                 "${_ad_test_name}"

--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -14,25 +14,29 @@
 
 include_guard()
 
+include(cmakepp_lang/cmakepp_lang)
+
 #[[[
-# This function will find all :code:`*.cmake` files in the specified directory as well as recursively through all subdirectories.
-# It will then configure the boilerplate template to include() each cmake file and register each configured boilerplate
-# with CTest. The configured templates will be executed seperately via CTest during the Test phase, and each *.cmake
-# file found in the specified directory is assumed to contain CMakeTest tests.
+# This function will find all :code:`*.cmake` files in the specified directory
+# as well as recursively through all subdirectories. It will then configure the
+# boilerplate template to include() each cmake file and register each
+# configured boilerplate with CTest. The configured templates will be executed
+# seperately via CTest during the Test phase, and each *.cmake file found in
+# the specified directory is assumed to contain CMakeTest tests.
 #
-# :param dir: The directory to search for *.cmake files. Subdirectories will be recursively searched.
-# :type dir: path
+# :param test_dir: The directory to search for *.cmake files containing tests.
+#                  Subdirectories will be recursively searched.
+# :type test_dir: path
 #
 # **Keyword Arguments**
 #
 # :keyword CMAKE_OPTIONS: List of additional CMake options to be
 #                         passed to all test invocations. Options
-#                         should follow the syntax: :code:`-D<variable_name>=<value>`
+#                         should follow the syntax:
+#                         :code:`-D<variable_name>=<value>`
 # :type CMAKE_OPTIONS: list
-#
-#
 #]]
-function(ct_add_dir _ad_dir)
+function(ct_add_dir _ad_test_dir)
     set(_ad_multi_value_args "CMAKE_OPTIONS")
     set(_ad_options CT_DEBUG_MODE_ON)
     cmake_parse_arguments(PARSE_ARGV 1 ADD_DIR "${_ad_options}" "" "${_ad_multi_value_args}")
@@ -40,31 +44,70 @@ function(ct_add_dir _ad_dir)
     # This variable will be picked up by the template
     set(ct_debug_mode "${ADD_DIR_CT_DEBUG_MODE_ON}")
 
-    get_filename_component(_ad_abs_test_dir "${_ad_dir}" REALPATH)
-    file(GLOB_RECURSE _ad_files LIST_DIRECTORIES FALSE FOLLOW_SYMLINKS "${_ad_abs_test_dir}/*.cmake") #Recurse over target dir to find all cmake files
+    # We expect to be given relative paths wrt the project, like
+    # ``ct_add_dir("test")``. This ensures we have an absolute path
+    # to the test directory when we do get a relative path. If we
+    # get an absolute path to begin with, this is essentially a no-op.
+    get_filename_component(_ad_abs_test_dir "${_ad_test_dir}" REALPATH)
 
-    foreach(_ad_test_file ${_ad_files})
-        #Find rel path so we don't end up with insanely long paths under test folders
-        file(RELATIVE_PATH _ad_rel_path "${_ad_abs_test_dir}" "${_ad_test_file}")
-        file(TO_CMAKE_PATH "${_ad_abs_test_dir}" _ad_normalized_dir)
-        string(REPLACE "/" "_" _ad_dir_prefix "${_ad_normalized_dir}")
-        string(REPLACE ":" "_" _ad_dir_prefix "${_ad_dir_prefix}")
+    # Recurse over the test directory to find all cmake files
+    # (assumed to all be test files)
+    file(GLOB_RECURSE
+        _ad_test_files
+        LIST_DIRECTORIES FALSE
+        FOLLOW_SYMLINKS "${_ad_abs_test_dir}/*.cmake"
+    )
 
-        #Fill in boilerplate, copy to build dir
+    # Each test file will get its own directory and "mini-project" in the
+    # build directory to facilitate independently running each test case.
+    # These directories are created from the mangled path to the source test
+    # file in the project to help ensure that each path is unique
+    foreach(_ad_test_file ${_ad_test_files})
+        # Normalize the absolute path to the project test directory, used in
+        # the build directory as a prefixing subdirectory to hold all of the
+        # test mini-projects from this test directory
+        file(TO_CMAKE_PATH "${_ad_abs_test_dir}" _ad_normalized_abs_test_dir)
+
+        # Find the relative path to the test file from the test directory to
+        # reduce the path length for the test folders created in the build
+        # directory. This is used for the test mini-project directory in the
+        # build directory
+        file(RELATIVE_PATH
+            _ad_test_file_rel_path
+            "${_ad_abs_test_dir}"
+            "${_ad_test_file}"
+        )
+
+        # string(REPLACE "/" "_" _ad_dir_prefix "${_ad_normalized_dir}")
+        # string(REPLACE ":" "_" _ad_dir_prefix "${_ad_dir_prefix}")
+
+        # Mangle all of the directory names derived from paths, since path
+        # strings commonly have characters that are illegal in file names
+        # mangle_path(_ad_dir_prefix_mangled "${_ad_normalized_abs_test_dir}")
+        # mangle_path(_ad_rel_path_mangled "${_ad_test_file_rel_path}")
+        cpp_sanitize_string(_ad_test_dest_prefix
+            "${_ad_normalized_abs_test_dir}"
+        )
+        cpp_sanitize_string(_ad_test_proj_dir "${_ad_test_file_rel_path}")
+
+        set(_ad_test_dest_full_path
+            "${CMAKE_CURRENT_BINARY_DIR}/tests/${_ad_test_dest_prefix}/${_ad_test_proj_dir}"
+        )
+
+        # Fill in boilerplate, copy to build dir
         configure_file(
             "${_CT_TEMPLATES_DIR}/lists.txt"
-            "${CMAKE_CURRENT_BINARY_DIR}/tests/${_ad_dir_prefix}/${_ad_rel_path}/src/CMakeLists.txt"
+            "${_ad_test_dest_full_path}/src/CMakeLists.txt"
             @ONLY
         )
         add_test(
         NAME
-            "${_ad_dir_prefix}_${_ad_rel_path}"
+            "${_ad_test_dest_prefix}_${_ad_test_proj_dir}"
         COMMAND
             "${CMAKE_COMMAND}"
-               -S "${CMAKE_CURRENT_BINARY_DIR}/tests/${_ad_dir_prefix}/${_ad_rel_path}/src"
-               -B "${CMAKE_CURRENT_BINARY_DIR}/tests/${_ad_dir_prefix}/${_ad_rel_path}"
+               -S "${_ad_test_dest_full_path}/src"
+               -B "${_ad_test_dest_full_path}"
                ${ADD_DIR_CMAKE_OPTIONS}
         )
-
     endforeach()
 endfunction()

--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -30,6 +30,8 @@ include(cmakepp_lang/cmakepp_lang)
 #
 # **Keyword Arguments**
 #
+# :keyword CT_DEBUG_MODE_ON: Enables debug mode when the tests are run.
+# :type CT_DEBUG_MODE_ON: bool
 # :keyword CMAKE_OPTIONS: List of additional CMake options to be
 #                         passed to all test invocations. Options
 #                         should follow the syntax:
@@ -38,6 +40,10 @@ include(cmakepp_lang/cmakepp_lang)
 #]]
 function(ct_add_dir _ad_test_dir)
     set(_ad_multi_value_args "CMAKE_OPTIONS")
+    # TODO: This name is potentially misleading because it seems to enable
+    #       debug mode for the test projects (see the use of 'ct_debug_mode'
+    #       in cmake/cmake_test/templates/test_project_CMakeLists.txt.in).
+    #       I propose renaming it to something like "ENABLE_DEBUG_MODE_IN_TESTS".
     set(_ad_options CT_DEBUG_MODE_ON)
     cmake_parse_arguments(PARSE_ARGV 1 ADD_DIR "${_ad_options}" "" "${_ad_multi_value_args}")
 

--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -70,11 +70,11 @@ function(ct_add_dir _ad_test_dir)
     # file in the project to help ensure that each path is unique
     foreach(_ad_test_file ${_ad_test_files})
         # Set the test file path for configuring the test mini-project
-        set(_CT_LISTS_TEMPLATE_TEST_FILE "${_ad_test_file}")
+        set(_CT_CMAKELISTS_TEMPLATE_TEST_FILE "${_ad_test_file}")
 
         # Sanitize the full path to the test file to get the mini-project name
         # for configuring the test mini-project
-        cpp_sanitize_string(_CT_LISTS_TEMPLATE_PROJECT_NAME "${_ad_test_file}")
+        cpp_sanitize_string(_CT_CMAKELISTS_TEMPLATE_PROJECT_NAME "${_ad_test_file}")
 
         # Normalize the absolute path to the project test directory, used in
         # the build directory as a prefixing subdirectory to hold all of the
@@ -105,7 +105,7 @@ function(ct_add_dir _ad_test_dir)
 
         # Configure the test mini-project in the build directory
         configure_file(
-            "${_CT_TEMPLATES_DIR}/test_project_CMakeLists.txt.in"
+            "${_CT_TEMPLATES_DIR}/test_CMakeLists.txt.in"
             "${_ad_test_dest_full_path}/src/CMakeLists.txt"
             @ONLY
         )

--- a/cmake/cmake_test/templates/test_CMakeLists.txt.in
+++ b/cmake/cmake_test/templates/test_CMakeLists.txt.in
@@ -24,8 +24,9 @@ set(CMAKE_MODULE_PATH
     CACHE STRING "" FORCE
 )
 
-# Question: Why not just set this to @ct_debug_mode@? I'm pretty sure that
-#           accomplishes the same thing.
+# Unconfirmed: This assignment is done in a seemily redundant way
+# because some CMakePPLang debug statements trigger just by
+# CMAKEPP_LANG_DEBUG_MODE being defined at all
 if(@ct_debug_mode@)
     set(CMAKEPP_LANG_DEBUG_MODE "TRUE")
 endif()
@@ -34,7 +35,6 @@ include(cmakepp_lang/cmakepp_lang)
 cpp_set_global("CT_DEBUG_MODE" "@ct_debug_mode@")
 
 include("cmake_test/cmake_test")
-# Question: Why is this set separately from above?
 set(CMAKEPP_LANG_DEBUG_MODE "@CMAKEPP_LANG_DEBUG_MODE@")
 
 include([[@_CT_CMAKELISTS_TEMPLATE_TEST_FILE@]])

--- a/cmake/cmake_test/templates/test_CMakeLists.txt.in
+++ b/cmake/cmake_test/templates/test_CMakeLists.txt.in
@@ -7,7 +7,7 @@ set(_ct_min_cmake_version @_ct_min_cmake_version@) #Propagate min version down
 
 # A language is set so the dummy projects don't complain about not having a
 # linkage language.
-project(@_CT_LISTS_TEMPLATE_PROJECT_NAME@ LANGUAGES C)
+project(@_CT_CMAKELISTS_TEMPLATE_PROJECT_NAME@ LANGUAGES C)
 
 #Enable colors in Unix environments, ignored on Windows. Will not work with pipes
 set(CMAKETEST_USE_COLORS "@CMAKETEST_USE_COLORS@")
@@ -24,6 +24,8 @@ set(CMAKE_MODULE_PATH
     CACHE STRING "" FORCE
 )
 
+# Question: Why not just set this to @ct_debug_mode@? I'm pretty sure that
+#           accomplishes the same thing.
 if(@ct_debug_mode@)
     set(CMAKEPP_LANG_DEBUG_MODE "TRUE")
 endif()
@@ -32,7 +34,8 @@ include(cmakepp_lang/cmakepp_lang)
 cpp_set_global("CT_DEBUG_MODE" "@ct_debug_mode@")
 
 include("cmake_test/cmake_test")
+# Question: Why is this set separately from above?
 set(CMAKEPP_LANG_DEBUG_MODE "@CMAKEPP_LANG_DEBUG_MODE@")
 
-include([[@_CT_LISTS_TEMPLATE_TEST_FILE@]])
+include([[@_CT_CMAKELISTS_TEMPLATE_TEST_FILE@]])
 ct_exec_tests()

--- a/cmake/cmake_test/templates/test_project_CMakeLists.txt.in
+++ b/cmake/cmake_test/templates/test_project_CMakeLists.txt.in
@@ -2,11 +2,12 @@
 #The configured file will be used as the CTest entrypoint and will
 #include() the intended test file before executing the tests found.
 
-
 cmake_minimum_required(VERSION @_ct_min_cmake_version@) #Required for FetchContent_MakeAvailable()
 set(_ct_min_cmake_version @_ct_min_cmake_version@) #Propagate min version down
-project(@_ad_test_file@ LANGUAGES C) #Needed so dummy libraries don't complain about not having a linkage language
 
+# A language is set so the dummy projects don't complain about not having a
+# linkage language.
+project(@_CT_LISTS_TEMPLATE_PROJECT_NAME@ LANGUAGES C)
 
 #Enable colors in Unix environments, ignored on Windows. Will not work with pipes
 set(CMAKETEST_USE_COLORS "@CMAKETEST_USE_COLORS@")
@@ -16,9 +17,12 @@ if(NOT CT_PRINT_LENGTH GREATER 0)
     set(CT_PRINT_LENGTH "@CT_PRINT_LENGTH@")
 endif()
 
-set(CMAKE_MODULE_PATH "@CMAKE_MODULE_PATH@" CACHE STRING "" FORCE)
-
-
+# Propagate the module CMake module path for the project so they stick when
+# the tests are run separately
+set(CMAKE_MODULE_PATH
+    "@CMAKE_MODULE_PATH@"
+    CACHE STRING "" FORCE
+)
 
 if(@ct_debug_mode@)
     set(CMAKEPP_LANG_DEBUG_MODE "TRUE")
@@ -30,5 +34,5 @@ cpp_set_global("CT_DEBUG_MODE" "@ct_debug_mode@")
 include("cmake_test/cmake_test")
 set(CMAKEPP_LANG_DEBUG_MODE "@CMAKEPP_LANG_DEBUG_MODE@")
 
-include([[@_ad_test_file@]])
+include([[@_CT_LISTS_TEMPLATE_TEST_FILE@]])
 ct_exec_tests()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
This issue was partially solved in #101. However, bugs related to it still remain and are reported in #109. This should fix #109 in a more robust way.

**Description**
Tests generated by CMakeTest using `ct_add_dir()` use the full path to the test file as a way to disambiguate the test "mini-projects" created in the build directory that are actually used to run the tests. On Windows, these path snippets are not properly being sanitized for their project name and folder name uses. This PR uses `cpp_sanitize_string()` from CMakePPLang to make convert the paths into file system-friendly strings where it is needed and cleans up a lot of the code in and associated with `ct_add_dir()`.

One other issue that I am immediately running up against on Windows is the [path length limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry) (256 characters). You can [opt-in](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later) to removing this limitation in Windows 10 or later, and attempt to limit object path and file lengths in CMake (see SO [post](https://stackoverflow.com/questions/68351713/maximum-path-lengths-with-cmake) and its answers), but even with all of that implemented I am running into compiler issues. It turns out that applications still have to be modified to take advantage of the path length being removed (see important note at the top of [this section](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#registry-setting-to-enable-long-paths)), which may be part of the issue. Additionally, to disable this max file path limitation you need administrator privileges, which will not be available to every user, and registry editing is always annoying and a dangerous task anyway.

Therefore, to even get the CMakeTest tests passing on Windows, I propose expanding this PR to include switching to a hash-based naming system based on the path strings ([string(\<HASH\>](https://cmake.org/cmake/help/latest/command/string.html#hashing)). We can use the file contents of the test file as well, if needed ([file(\<HASH\>](https://cmake.org/cmake/help/v3.5/command/file.html)). 

**TODOs**
- [x] Implement the hash-based naming system for tests.
