### PR TITLE
Uses outer project's languages for tests

### DIFF
--- a/cmake/cmake_test/add_dir.cmake
+++ b/cmake/cmake_test/add_dir.cmake
@@ -130,6 +130,7 @@ function(ct_add_dir _ad_test_dir)
         )
 
         # Configure the CMakeLists.txt for test in the build directory
+        cpp_enabled_languages(_CT_LANGUAGES)
         configure_file(
             "${_CT_TEMPLATES_DIR}/test_CMakeLists.txt.in"
             "${_ad_test_dest_full_path}/src/CMakeLists.txt"

--- a/cmake/cmake_test/templates/test_CMakeLists.txt.in
+++ b/cmake/cmake_test/templates/test_CMakeLists.txt.in
@@ -7,7 +7,7 @@ set(_ct_min_cmake_version @_ct_min_cmake_version@) #Propagate min version down
 
 # A language is set so the dummy projects don't complain about not having a
 # linkage language.
-project(@_CT_CMAKELISTS_TEMPLATE_PROJECT_NAME@ LANGUAGES C)
+project(@_CT_CMAKELISTS_TEMPLATE_PROJECT_NAME@ LANGUAGES @_CT_LANGUAGES@)
 
 #Enable colors in Unix environments, ignored on Windows. Will not work with pipes
 set(CMAKETEST_USE_COLORS "@CMAKETEST_USE_COLORS@")

--- a/cmake/versions.cmake
+++ b/cmake/versions.cmake
@@ -14,5 +14,5 @@
 
 include_guard()
 
-set(CMAKEPP_LANG_VERSION v1.0.0)
+set(CMAKEPP_LANG_VERSION v1.1.0)
 set(CMAIZE_VERSION v0.2.1)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,5 +12,6 @@ ct_set_print_length("${CT_DEFAULT_PRINT_LENGTH}")
 
 set(CMAKEPP_LANG_DEBUG_MODE ON)
 
+add_subdirectory("add_dir_test")
 ct_add_dir("./cmake_test" CT_DEBUG_MODE_ON)
 ct_add_dir("./test_directory_2" CT_DEBUG_MODE_ON)

--- a/tests/add_dir_test/CMakeLists.txt
+++ b/tests/add_dir_test/CMakeLists.txt
@@ -1,0 +1,4 @@
+enable_language(CXX)
+ct_add_dir("./forward_languages" LANGUAGES FORWARD_LANGUAGES)
+ct_add_dir("./no_language_set")
+ct_add_dir("./set_languages" LANGUAGES C CXX)

--- a/tests/add_dir_test/forward_languages/test_forward_language.cmake
+++ b/tests/add_dir_test/forward_languages/test_forward_language.cmake
@@ -1,0 +1,7 @@
+ct_add_test(NAME test_forward_languages)
+function(${test_forward_languages})
+    cpp_enabled_languages(the_enabled_languages)
+
+    set(correct_value "CXX")
+    ct_assert_equal(the_enabled_languages "${correct_value}")
+endfunction()

--- a/tests/add_dir_test/no_language_set/test_no_language_set.cmake
+++ b/tests/add_dir_test/no_language_set/test_no_language_set.cmake
@@ -1,0 +1,7 @@
+ct_add_test(NAME test_no_language_set)
+function(${test_no_language_set})
+    cpp_enabled_languages(the_enabled_languages)
+
+    set(correct_value "C")
+    ct_assert_equal(the_enabled_languages "${correct_value}")
+endfunction()

--- a/tests/add_dir_test/set_languages/test_set_languages.cmake
+++ b/tests/add_dir_test/set_languages/test_set_languages.cmake
@@ -1,0 +1,7 @@
+ct_add_test(NAME test_set_languages)
+function(${test_set_languages})
+    cpp_enabled_languages(the_enabled_languages)
+
+    set(correct_value "C;CXX")
+    ct_assert_equal(the_enabled_languages "${correct_value}")
+endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Partially addresses #118.

**Description**
CMakeTest works by creating CMake projects for each test. Those projects need to invoke the `project()` command. Previously, we had been hard-coding the language to `C`. This PR changes that so that we now use the languages the user is using.

**TODOs**
- [x] Merge CMakePP/CMakePPLang#136