### PR TITLE
Update documentation for EXPECTFAIL

### DIFF
--- a/tests/cmake_test/expectfail.cmake
+++ b/tests/cmake_test/expectfail.cmake
@@ -5,7 +5,7 @@ include(cmake_test/cmake_test)
 # in an EXPECTFAIL test will allow the test to succeed.
 #]]
 ct_add_test(NAME "make_sure_function_fails" EXPECTFAIL)
-function("${CMAKETEST_TEST}")
+function("${make_sure_function_fails}")
 
     function(failing_fxn)
         message(FATAL_ERROR "I have erred.")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Sort of related to #122, but does not fix it.

**Description**
To implicitly discourage people from using `CMAKETEST_TEST` when a test should fail the example falls back to using the name of the function. I want to stop short of telling people not to use it in case we don't actually need to deprecate it.

**TODOs**
R2g.
